### PR TITLE
Fix ServerEvents.postStart not called

### DIFF
--- a/silk-core/src/main/java/net/silkmc/silk/core/mixin/server/MixinMinecraftServer.java
+++ b/silk-core/src/main/java/net/silkmc/silk/core/mixin/server/MixinMinecraftServer.java
@@ -26,7 +26,7 @@ public class MixinMinecraftServer {
         method = "runServer",
         at = @At(
             value = "INVOKE",
-            target = "Lnet/minecraft/server/MinecraftServer;loadStatusIcon()Ljava/util/Optional;",
+            target = "Lnet/minecraft/server/MinecraftServer;buildServerStatus()Lnet/minecraft/network/protocol/status/ServerStatus;",
             shift = At.Shift.AFTER
         )
     )

--- a/silk-core/src/main/java/net/silkmc/silk/core/mixin/server/MixinMinecraftServer.java
+++ b/silk-core/src/main/java/net/silkmc/silk/core/mixin/server/MixinMinecraftServer.java
@@ -26,7 +26,7 @@ public class MixinMinecraftServer {
         method = "runServer",
         at = @At(
             value = "INVOKE",
-            target = "Lnet/minecraft/server/MinecraftServer;updateStatusIcon(Lnet/minecraft/network/protocol/status/ServerStatus;)V",
+            target = "Lnet/minecraft/server/MinecraftServer;loadStatusIcon()Ljava/util/Optional;",
             shift = At.Shift.AFTER
         )
     )


### PR DESCRIPTION
This PR fixes the `MinecraftServer` mixin so that the `Events.Server.postStart` event get's called (mixin target is broken since mc 1.19.4).