### PR TITLE
silk-game: Fix sideboards for 1.19.4

### DIFF
--- a/silk-game/src/main/kotlin/net/silkmc/silk/game/sideboard/Sideboard.kt
+++ b/silk-game/src/main/kotlin/net/silkmc/silk/game/sideboard/Sideboard.kt
@@ -53,7 +53,7 @@ class Sideboard(
      */
     fun hideFromPlayer(player: ServerPlayer) {
         silkCoroutineScope.launch {
-            scoreboard.displayToPlayer(player)
+            scoreboard.hideFromPlayer(player)
         }
     }
 }

--- a/silk-game/src/main/kotlin/net/silkmc/silk/game/sideboard/internal/SideboardScoreboard.kt
+++ b/silk-game/src/main/kotlin/net/silkmc/silk/game/sideboard/internal/SideboardScoreboard.kt
@@ -76,8 +76,8 @@ class SideboardScoreboard(
 
                 // add line packets
                 lines.access {
-                    it.forEach { line ->
-                        this@buildList.addAll(line.createInitPackets(0))
+                    it.reversed().forEachIndexed { score, line ->
+                        this@buildList.addAll(line.createInitPackets(score))
                     }
                 }
 

--- a/silk-game/src/main/kotlin/net/silkmc/silk/game/sideboard/internal/SideboardScoreboard.kt
+++ b/silk-game/src/main/kotlin/net/silkmc/silk/game/sideboard/internal/SideboardScoreboard.kt
@@ -76,8 +76,8 @@ class SideboardScoreboard(
 
                 // add line packets
                 lines.access {
-                    it.reversed().forEachIndexed { score, line ->
-                        this@buildList.addAll(line.createInitPackets(score))
+                    it.reversed().forEachIndexed { index, line ->
+                        this@buildList.addAll(line.createInitPackets(index))
                     }
                 }
 
@@ -168,8 +168,6 @@ class SideboardScoreboard(
             line = Line(index)
             it.add(line)
         }
-        line.createInitPackets(0)
-            .forEach(::emitPacket)
         return line
     }
 }


### PR DESCRIPTION
This PR fixes the following things related to the sideboard api:
- `sideboard.hideFromPlayer()` now actually calls the internal `scoreboard.hideFromPlayer()` method instead of calling the `scoreboard.displayToPlayer()` method again.
- The matching score number is sent with the init packet, thereby fixing the issues in 1.19.4 with the order of the displayed sideboard lines.

![grafik](https://github.com/SilkMC/silk/assets/59575572/363be8ff-d70e-4153-abef-e3e813fb7f82)
![grafik](https://github.com/SilkMC/silk/assets/59575572/b52e4057-24fe-4b37-bc26-75faedf8f3fb)
