### PR TITLE
new setLore funciton in style of `setCustomName`

### DIFF
--- a/silk-core/src/main/kotlin/net/silkmc/silk/core/item/ItemBuilder.kt
+++ b/silk-core/src/main/kotlin/net/silkmc/silk/core/item/ItemBuilder.kt
@@ -42,6 +42,17 @@ fun ItemStack.setLore(text: Collection<Component>) {
 }
 
 /**
+ * Sets the item lore, which is displayed below the display
+ * name of the item stack. Each child of the first children of
+ * the generated literal text represents one line.
+ */
+fun ItemStack.setLore(baseText: String = "", builder: LiteralTextBuilder.() -> Unit) {
+    literalText(baseText, builder).siblings.firstOrNull()?.let {
+        setLore(it.siblings)
+    }
+}
+
+/**
  * Opens a [LiteralTextBuilder] to change the custom name of
  * the item stack. See [literalText].
  */


### PR DESCRIPTION
it feels wrong calling setLore like this

setLore(listOf(literalText(...) { ... }...