### PR TITLE
Update to Minecraft 1.21 and Kotlin 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Gradle
 .gradle/
 build/
+.kotlin/
 
 # Editors (add yours if applicable)
 .idea/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 
 allprojects {
     group = "net.silkmc"
-    version = "1.10.6"
+    version = "1.10.7"
     if (this.name.startsWith("silk")) {
         description = "Silk is a Minecraft API for Kotlin"
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,8 +24,8 @@ dependencies {
     implementation(pluginDep("fabric-loom", "1.6-SNAPSHOT"))
     implementation(pluginDep("com.modrinth.minotaur", "2.8.7"))
 
-    implementation(pluginDep("io.papermc.paperweight.userdev", "1.5.11"))
-    implementation(pluginDep("xyz.jpenilla.run-paper", "2.2.3"))
+    implementation(pluginDep("io.papermc.paperweight.userdev", "1.7.1"))
+    implementation(pluginDep("xyz.jpenilla.run-paper", "2.3.0"))
 
     val compileDokkaVersion = "1.9.20"
     val dokkaVersion = "1.9.20"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 dependencies {
     fun pluginDep(id: String, version: String) = "${id}:${id}.gradle.plugin:${version}"
 
-    val kotlinVersion = "1.9.23"
+    val kotlinVersion = "2.0.0"
 
     compileOnly(kotlin("gradle-plugin", embeddedKotlinVersion))
     runtimeOnly(kotlin("gradle-plugin", kotlinVersion))

--- a/buildSrc/src/main/kotlin/BuildConstants.kt
+++ b/buildSrc/src/main/kotlin/BuildConstants.kt
@@ -15,7 +15,7 @@ object BuildConstants {
     const val majorMinecraftVersion = "1.21"
 
     // check these values here: https://jakobk.net/mcdev
-    const val minecraftVersion = "1.21-rc1"
+    const val minecraftVersion = "1.21"
     const val fabricLoaderVersion = "0.15.11"
     const val fabricLanguageKotlinVersion = "1.11.0+kotlin.2.0.0"
 

--- a/buildSrc/src/main/kotlin/BuildConstants.kt
+++ b/buildSrc/src/main/kotlin/BuildConstants.kt
@@ -12,15 +12,15 @@ object BuildConstants {
 
     val authors = listOf("jakobkmar", "_F0X")
 
-    const val majorMinecraftVersion = "1.20"
+    const val majorMinecraftVersion = "1.21"
 
     // check these values here: https://jakobk.net/mcdev
-    const val minecraftVersion = "1.20.6"
+    const val minecraftVersion = "1.21-rc1"
     const val fabricLoaderVersion = "0.15.11"
-    const val fabricLanguageKotlinVersion = "1.10.19+kotlin.1.9.23"
+    const val fabricLanguageKotlinVersion = "1.11.0+kotlin.2.0.0"
 
-    const val kotestVersion = "5.8.1"
-    const val mockkVersion = "1.13.10"
+    const val kotestVersion = "5.9.1"
+    const val mockkVersion = "1.13.11"
 
     val uploadModules = listOf(
         "commands",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/silk-core/src/main/java/net/silkmc/silk/core/mixin/server/MixinServerConfigurationPacketListenerImpl.java
+++ b/silk-core/src/main/java/net/silkmc/silk/core/mixin/server/MixinServerConfigurationPacketListenerImpl.java
@@ -1,7 +1,7 @@
 package net.silkmc.silk.core.mixin.server;
 
 import com.mojang.authlib.GameProfile;
-import net.minecraft.network.chat.Component;
+import net.minecraft.network.DisconnectionDetails;
 import net.minecraft.server.network.ServerConfigurationPacketListenerImpl;
 import net.silkmc.silk.core.event.PlayerEvents;
 import org.spongepowered.asm.mixin.Mixin;
@@ -19,9 +19,9 @@ public abstract class MixinServerConfigurationPacketListenerImpl {
         method = "onDisconnect",
         at = @At("HEAD")
     )
-    private void onQuitDuringConfiguration(Component reason,
+    private void onQuitDuringConfiguration(DisconnectionDetails disconnectionDetails,
                                            CallbackInfo ci) {
         PlayerEvents.INSTANCE.getQuitDuringConfiguration()
-            .invoke(new PlayerEvents.PlayerQuitDuringLoginEvent(playerProfile(), reason));
+            .invoke(new PlayerEvents.PlayerQuitDuringLoginEvent(playerProfile(), disconnectionDetails.reason()));
     }
 }

--- a/silk-core/src/main/java/net/silkmc/silk/core/mixin/server/MixinServerGamePacketListenerImpl.java
+++ b/silk-core/src/main/java/net/silkmc/silk/core/mixin/server/MixinServerGamePacketListenerImpl.java
@@ -1,6 +1,6 @@
 package net.silkmc.silk.core.mixin.server;
 
-import net.minecraft.network.chat.Component;
+import net.minecraft.network.DisconnectionDetails;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.silkmc.silk.core.event.PlayerEvents;
@@ -19,9 +19,9 @@ public abstract class MixinServerGamePacketListenerImpl {
         method = "onDisconnect",
         at = @At("HEAD")
     )
-    private void onPreQuit(Component reason,
+    private void onPreQuit(DisconnectionDetails disconnectionDetails,
                            CallbackInfo ci) {
         PlayerEvents.INSTANCE.getPreQuit()
-            .invoke(new PlayerEvents.PlayerQuitEvent(player, reason));
+            .invoke(new PlayerEvents.PlayerQuitEvent(player, disconnectionDetails.reason()));
     }
 }

--- a/silk-core/src/main/java/net/silkmc/silk/core/mixin/server/MixinServerLoginPacketListenerImpl.java
+++ b/silk-core/src/main/java/net/silkmc/silk/core/mixin/server/MixinServerLoginPacketListenerImpl.java
@@ -1,7 +1,7 @@
 package net.silkmc.silk.core.mixin.server;
 
 import com.mojang.authlib.GameProfile;
-import net.minecraft.network.chat.Component;
+import net.minecraft.network.DisconnectionDetails;
 import net.minecraft.server.network.ServerLoginPacketListenerImpl;
 import net.silkmc.silk.core.event.PlayerEvents;
 import org.jetbrains.annotations.Nullable;
@@ -20,9 +20,9 @@ public abstract class MixinServerLoginPacketListenerImpl {
         method = "onDisconnect",
         at = @At("HEAD")
     )
-    private void onQuitDuringLogin(Component reason,
+    private void onQuitDuringLogin(DisconnectionDetails disconnectionDetails,
                                    CallbackInfo ci) {
         PlayerEvents.INSTANCE.getQuitDuringLogin()
-            .invoke(new PlayerEvents.PlayerQuitDuringLoginEvent(authenticatedProfile, reason));
+            .invoke(new PlayerEvents.PlayerQuitDuringLoginEvent(authenticatedProfile, disconnectionDetails.reason()));
     }
 }

--- a/silk-core/src/main/kotlin/net/silkmc/silk/core/entity/MovementExtensions.kt
+++ b/silk-core/src/main/kotlin/net/silkmc/silk/core/entity/MovementExtensions.kt
@@ -4,6 +4,7 @@ import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.level.portal.DimensionTransition
 import net.minecraft.world.phys.Vec3
 
 /**
@@ -29,7 +30,11 @@ fun Entity.changePos(
     }
 
     if (world != null && world != this.level()) {
-        changeDimension(world)
+        changeDimension(DimensionTransition(
+            world, Vec3(xD, yD, zD), Vec3.ZERO, yaw ?: this.yRot,
+            pitch ?: this.xRot, false, DimensionTransition.DO_NOTHING
+        ))
+        return
     }
 
     if (yaw != null) this.yRot = yaw

--- a/silk-core/src/main/kotlin/net/silkmc/silk/core/serialization/serializers/ResourceLocationSerializer.kt
+++ b/silk-core/src/main/kotlin/net/silkmc/silk/core/serialization/serializers/ResourceLocationSerializer.kt
@@ -10,8 +10,7 @@ typealias IdentifierSerializer = ResourceLocationSerializer
 
 class ResourceLocationSerializer : SilkSerializer<ResourceLocation>() {
     override fun deserialize(decoder: Decoder): ResourceLocation {
-        val split = decoder.decodeString().split(':')
-        return ResourceLocation(split[0], split[1])
+        return ResourceLocation.bySeparator(decoder.decodeString(), ':')
     }
 
     override fun serialize(encoder: Encoder, value: ResourceLocation) {

--- a/silk-core/src/main/kotlin/net/silkmc/silk/core/server/ServerExtensions.kt
+++ b/silk-core/src/main/kotlin/net/silkmc/silk/core/server/ServerExtensions.kt
@@ -37,4 +37,4 @@ val MinecraftServer.players: List<ServerPlayer>
  * absolute [Path].
  */
 val MinecraftServer.serverPath: Path
-    get() = serverDirectory.toPath().absolute()
+    get() = serverDirectory.absolute()

--- a/silk-core/src/main/kotlin/net/silkmc/silk/core/server/ServerExtensions.kt
+++ b/silk-core/src/main/kotlin/net/silkmc/silk/core/server/ServerExtensions.kt
@@ -36,5 +36,9 @@ val MinecraftServer.players: List<ServerPlayer>
  * Returns the current run directory of the server as an
  * absolute [Path].
  */
+@Deprecated(
+    message = "Minecraft now offers a 'serverDirectory' property, use that instead.",
+    replaceWith = ReplaceWith("serverDirectory.absolute()", "kotlin.io.path.absolute"),
+)
 val MinecraftServer.serverPath: Path
     get() = serverDirectory.absolute()

--- a/silk-game/src/main/kotlin/net/silkmc/silk/game/sideboard/internal/SideboardScoreboard.kt
+++ b/silk-game/src/main/kotlin/net/silkmc/silk/game/sideboard/internal/SideboardScoreboard.kt
@@ -143,12 +143,9 @@ class SideboardScoreboard(
     }
 
     suspend fun addLine(initialContent: Component): Line {
-        val line: Line
-        lines.access {
+        return lines.access {
             val index = it.lastIndex + 1
-            line = Line(index, initialContent)
-            it.add(line)
+            Line(index, initialContent).apply { it.add(this) }
         }
-        return line
     }
 }

--- a/silk-network/src/main/kotlin/net/silkmc/silk/network/packet/PacketDefinition.kt
+++ b/silk-network/src/main/kotlin/net/silkmc/silk/network/packet/PacketDefinition.kt
@@ -32,7 +32,7 @@ sealed class AbstractPacketDefinition<T : Any, C>(
     protected val receiverScope = CoroutineScope(Dispatchers.Default.limitedParallelism(1))
 
     @InternalSilkApi
-    val type: CustomPacketPayload.Type<SilkPacketPayload> = CustomPacketPayload.createType(id.toString())
+    val type: CustomPacketPayload.Type<SilkPacketPayload> = CustomPacketPayload.Type(id)
 
     @InternalSilkApi
     val streamCodec: StreamCodec<FriendlyByteBuf, SilkPacketPayload> =

--- a/silk-persistence/src/main/java/net/silkmc/silk/persistence/mixin/chunk/ChunkSerializerMixin.java
+++ b/silk-persistence/src/main/java/net/silkmc/silk/persistence/mixin/chunk/ChunkSerializerMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ProtoChunk;
 import net.minecraft.world.level.chunk.storage.ChunkSerializer;
+import net.minecraft.world.level.chunk.storage.RegionStorageInfo;
 import net.silkmc.silk.persistence.CompoundProvider;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -27,6 +28,7 @@ public class ChunkSerializerMixin {
     @Inject(method = "read", at = @At("RETURN"))
     private static void onDeserialize(ServerLevel world,
                                       PoiManager poiStorage,
+                                      RegionStorageInfo regionStorageInfo,
                                       ChunkPos pos,
                                       CompoundTag nbt,
                                       CallbackInfoReturnable<ProtoChunk> cir) {

--- a/silk-testmod/src/main/kotlin/net/silkmc/silk/test/Identifier.kt
+++ b/silk-testmod/src/main/kotlin/net/silkmc/silk/test/Identifier.kt
@@ -3,4 +3,4 @@ package net.silkmc.silk.test
 import net.minecraft.resources.ResourceLocation
 
 val String.testmodId
-    get() = ResourceLocation("silk-testmod", this)
+    get() = ResourceLocation.fromNamespaceAndPath("silk-testmod", this)

--- a/silk-testmod/src/main/kotlin/net/silkmc/silk/test/commands/ItemTestCommand.kt
+++ b/silk-testmod/src/main/kotlin/net/silkmc/silk/test/commands/ItemTestCommand.kt
@@ -1,5 +1,6 @@
 package net.silkmc.silk.test.commands
 
+import net.minecraft.core.registries.Registries
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.item.Items
 import net.minecraft.world.item.alchemy.Potions
@@ -8,7 +9,8 @@ import net.silkmc.silk.core.item.*
 
 private fun createItems(player: ServerPlayer) = listOf(
     itemStack(Items.NETHERITE_SWORD) {
-        enchant(Enchantments.SHARPNESS, 2)
+        val enchantmentRegistry = player.level().registryAccess().registryOrThrow(Registries.ENCHANTMENT)
+        enchant(enchantmentRegistry.getHolderOrThrow(Enchantments.SHARPNESS), 2)
     },
     itemStack(Items.POTION) {
         setPotion(Potions.LEAPING)


### PR DESCRIPTION
Minecraft 1.21-rc1 is out so here I am. A few notes:
- Bumped Silk version to 1.10.7
- K2 compiler now uses .kotlin directory for some cache so I added it to .gitignore
- I tried updating kotlinx-serialization to 1.7.0 but for some reason it says that I'm still using Kotlin 1.9.22 and so I need to downgrade, idk why
- I changed `addLine` function because K2 compiler is unable to compile it in the previous form