### PR TITLE
Implement Silk entity events in paper module

### DIFF
--- a/silk-paper/src/main/kotlin/net/silkmc/silk/paper/conversions/NativeMcConversions.kt
+++ b/silk-paper/src/main/kotlin/net/silkmc/silk/paper/conversions/NativeMcConversions.kt
@@ -2,10 +2,13 @@ package net.silkmc.silk.paper.conversions
 
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.dedicated.DedicatedServer
+import net.minecraft.server.level.ServerEntity
 import net.minecraft.server.level.ServerPlayer
 import org.bukkit.Server
 import org.bukkit.craftbukkit.CraftServer
+import org.bukkit.craftbukkit.entity.CraftEntity
 import org.bukkit.craftbukkit.entity.CraftPlayer
+import org.bukkit.entity.Entity
 import org.bukkit.entity.Player
 
 /**
@@ -20,3 +23,9 @@ val Server.mcServer: MinecraftServer
  */
 val Player.mcPlayer: ServerPlayer
     get() = (this as CraftPlayer).handle
+
+/**
+ * Converts a Paper [Entity] to a native [net.minecraft.world.entity.Entity]. The instance should be a [ServerEntity], but this api does not guarantee that.
+ */
+val Entity.mcEntity: net.minecraft.world.entity.Entity
+    get() = (this as CraftEntity).handle

--- a/silk-paper/src/main/kotlin/net/silkmc/silk/paper/events/internal/EntityEvents.kt
+++ b/silk-paper/src/main/kotlin/net/silkmc/silk/paper/events/internal/EntityEvents.kt
@@ -1,0 +1,19 @@
+package net.silkmc.silk.paper.events.internal
+
+import net.minecraft.world.entity.LivingEntity
+import net.silkmc.silk.core.event.EntityEvents
+import net.silkmc.silk.core.event.EventScopeProperty
+import net.silkmc.silk.paper.conversions.mcEntity
+import net.silkmc.silk.paper.events.listenSilk
+import org.bukkit.craftbukkit.damage.CraftDamageSource
+import org.bukkit.event.entity.EntityDamageEvent
+
+fun EntityEvents.setupPaper() {
+    listenSilk<EntityDamageEvent> {
+        val mcEntity = it.entity.mcEntity
+        checkInvulnerability.invoke(EntityEvents.EntityCheckInvulnerabilityEvent(mcEntity, (it.damageSource as CraftDamageSource).handle, EventScopeProperty(it.isCancelled)))
+        if (mcEntity is LivingEntity) {
+            damageLivingEntity.invoke(EntityEvents.EntityDamageEvent(mcEntity, it.finalDamage.toFloat(), (it.damageSource as CraftDamageSource).handle))
+        }
+    }
+}

--- a/silk-paper/src/main/kotlin/net/silkmc/silk/paper/internal/SilkPaperEntrypoint.kt
+++ b/silk-paper/src/main/kotlin/net/silkmc/silk/paper/internal/SilkPaperEntrypoint.kt
@@ -1,6 +1,7 @@
 package net.silkmc.silk.paper.internal
 
 import net.silkmc.silk.core.annotations.InternalSilkApi
+import net.silkmc.silk.core.event.Entity
 import net.silkmc.silk.core.event.Events
 import net.silkmc.silk.core.event.Player
 import net.silkmc.silk.core.event.Server
@@ -21,6 +22,7 @@ class SilkPaperEntrypoint : JavaPlugin(), Listener {
 
         Events.Server.setupPaper()
         Events.Player.setupPaper()
+        Events.Entity.setupPaper()
     }
 
     override fun onEnable() {


### PR DESCRIPTION
Add a paper implementation for the `damageLivingEntity` and `checkInvulnerability` event. 

The paper EntityDamageEvent is triggered for any entity that is attempted to be damaged, even if the entity is invulnerable. This will not trigger for attacks on entities with spam hitting like vehicles (minecrafts, boats...) and armor stands and may need to be extended.