### PR TITLE
Update 1.21.4 & Gradle remapping fix

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     compileOnly(pluginDep("org.jetbrains.kotlin.plugin.serialization", embeddedKotlinVersion))
     runtimeOnly(pluginDep("org.jetbrains.kotlin.plugin.serialization", kotlinVersion))
 
-    implementation(pluginDep("fabric-loom", "1.8-SNAPSHOT"))
+    implementation(pluginDep("fabric-loom", "1.9-SNAPSHOT"))
     implementation(pluginDep("com.modrinth.minotaur", "2.8.7"))
 
     implementation(pluginDep("io.papermc.paperweight.userdev", "1.7.2"))

--- a/buildSrc/src/main/kotlin/BuildConstants.kt
+++ b/buildSrc/src/main/kotlin/BuildConstants.kt
@@ -16,9 +16,9 @@ object BuildConstants {
 
     // check these values here: https://jakobk.net/mcdev
     const val majorMinecraftVersion = "1.21"
-    const val minecraftVersion = "$majorMinecraftVersion.2"
+    const val minecraftVersion = "$majorMinecraftVersion.4"
     const val paperMinecraftVersion = "1.21.1"
-    const val fabricLoaderVersion = "0.16.7"
+    const val fabricLoaderVersion = "0.16.10"
     const val fabricLanguageKotlinVersion = "1.12.3+kotlin.2.0.21"
 
     const val kotestVersion = "5.9.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/silk-all/build.gradle.kts
+++ b/silk-all/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 dependencies {
     BuildConstants.uploadModules.forEach {
-        implementation(include(modProject(":${rootProject.name}-${it}"))!!)
+        implementation(include(project(":${rootProject.name}-${it}"))!!)
     }
 }
 


### PR DESCRIPTION
Updated build constants to 1.21.4, supporting versions of 1.21.2-1.21.4 and fixing an issue that building `silk-all` bundled all dev module jars instead of remapped jars